### PR TITLE
Added path normalization of '\' to '/' + Prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require("path");
 
 function isParentFolder(path) {
   return path.startsWith("../");
@@ -9,7 +9,13 @@ function isSameFolder(path) {
 }
 
 function getAbsolutePath(relativePath, context) {
-  return path.relative(context.getCwd(), path.join(path.dirname(context.getFilename()), relativePath));
+  return path
+    .relative(
+      context.getCwd(),
+      path.join(path.dirname(context.getFilename()), relativePath)
+    )
+    .split(path.sep)
+    .join("/");
 }
 
 const message = "import statements should have an absolute path";
@@ -32,7 +38,10 @@ module.exports = {
                 node,
                 message: message,
                 fix: function (fixer) {
-                  return fixer.replaceTextRange([node.source.range[0] + 1, node.source.range[1] - 1], getAbsolutePath(path, context));
+                  return fixer.replaceTextRange(
+                    [node.source.range[0] + 1, node.source.range[1] - 1],
+                    getAbsolutePath(path, context)
+                  );
                 },
               });
             }
@@ -42,7 +51,10 @@ module.exports = {
                 node,
                 message: message,
                 fix: function (fixer) {
-                  return fixer.replaceTextRange([node.source.range[0] + 1, node.source.range[1] - 1], getAbsolutePath(path, context));
+                  return fixer.replaceTextRange(
+                    [node.source.range[0] + 1, node.source.range[1] - 1],
+                    getAbsolutePath(path, context)
+                  );
                 },
               });
             }


### PR DESCRIPTION
The previous implementation was not working properly on Windows because of the [default separator used by the Path module](https://nodejs.org/api/path.html#pathsep).

- Added normalization of the result
- Prettier automatically ran on the code