### PR TITLE
add rootDir config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add the plugin to the plugins section, and configure the rule options.
 ...
 "no-relative-import-paths/no-relative-import-paths": [
   "warn",
-  { "allowSameFolder": true }
+  { "allowSameFolder": true, "rootDir": "src" }
 ]
 ...
 ```
@@ -61,3 +61,27 @@ import Something from "./something";
 // will always generate a warning
 import Something from "../modules/something";
 ```
+
+### `rootDir`
+
+Useful when auto-fixing and the rootDir should not be included in the absolute path.
+
+Examples of code for this rule:
+
+```js
+// when not configured:
+import Something from "../../components/something";
+
+// will result in
+import Something from "src/components/something";
+```
+
+```js
+// when configured as { "rootDir": "src" }
+import Something from "../../components/something";
+
+// will result in
+import Something from "components/something";
+//                     ^- no 'src/' prefix is added
+```
+

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 const path = require("path");
 
-function isParentFolder(path) {
-  return path.startsWith("../");
+function isParentFolder(relativeFilePath, context, rootDir) {
+  const absoluteRootPath = context.getCwd() + (rootDir !== '' ? path.sep + rootDir : '');
+  const absoluteFilePath = path.join(path.dirname(context.getFilename()), relativeFilePath)
+
+  return relativeFilePath.startsWith("../") && (rootDir === '' || absoluteFilePath.startsWith(absoluteRootPath));
 }
 
 function isSameFolder(path) {
@@ -33,7 +36,7 @@ module.exports = {
         return {
           ImportDeclaration: function (node) {
             const path = node.source.value;
-            if (isParentFolder(path)) {
+            if (isParentFolder(path, context, rootDir)) {
               context.report({
                 node,
                 message: message,

--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ function isSameFolder(path) {
   return path.startsWith("./");
 }
 
-function getAbsolutePath(relativePath, context) {
+function getAbsolutePath(relativePath, context, rootDir) {
   return path
     .relative(
-      context.getCwd(),
+      context.getCwd() + (rootDir !== '' ? path.sep + rootDir : ''),
       path.join(path.dirname(context.getFilename()), relativePath)
     )
     .split(path.sep)
@@ -28,7 +28,7 @@ module.exports = {
         fixable: "code",
       },
       create: function (context) {
-        const { allowSameFolder } = context.options[0] || {};
+        const { allowSameFolder, rootDir } = context.options[0] || {};
 
         return {
           ImportDeclaration: function (node) {
@@ -40,7 +40,7 @@ module.exports = {
                 fix: function (fixer) {
                   return fixer.replaceTextRange(
                     [node.source.range[0] + 1, node.source.range[1] - 1],
-                    getAbsolutePath(path, context)
+                    getAbsolutePath(path, context, rootDir || '')
                   );
                 },
               });
@@ -53,7 +53,7 @@ module.exports = {
                 fix: function (fixer) {
                   return fixer.replaceTextRange(
                     [node.source.range[0] + 1, node.source.range[1] - 1],
-                    getAbsolutePath(path, context)
+                    getAbsolutePath(path, context, rootDir || '')
                   );
                 },
               });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-no-relative-import-paths",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Hi!

In a nextjs project, I noticed relative paths being rewritten to 'src/components/SomeComponent' instead of 'components/SomeComponent'. This PR adds a new config option `rootDir` to solve that problem.

E.g. `{ "rootDir": "src" }` solves the issue I was seeing.

If this behavior is already configurable via some other eslint setting, I would be interested to learn about that!