### PR TITLE
Fix parentfolder check

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,11 @@ function isParentFolder(relativeFilePath, context, rootDir) {
   const absoluteRootPath = context.getCwd() + (rootDir !== '' ? path.sep + rootDir : '');
   const absoluteFilePath = path.join(path.dirname(context.getFilename()), relativeFilePath)
 
-  return relativeFilePath.startsWith("../") && (rootDir === '' || absoluteFilePath.startsWith(absoluteRootPath));
+  return relativeFilePath.startsWith("../") && (
+    rootDir === '' ||
+    (absoluteFilePath.startsWith(absoluteRootPath) &&
+    context.getFilename().startsWith(absoluteRootPath))
+  );
 }
 
 function isSameFolder(path) {


### PR DESCRIPTION
This fixes a small issue where imports are incorrectly rewritten.

## The bug

Example:

```
// in file: cypress/integration/test.ts
import config from '../../src/config'
```

was being rewritten to
```
# in file: cypress/integration/test.ts
import config from 'config'
```

### Fix 

This PR extends  `isParentFolder` to check if the import can be safely rewritten.