### PR TITLE
Fix options can be undefined instead of having a default value

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,10 @@ module.exports = {
         fixable: "code",
       },
       create: function (context) {
-        const { allowSameFolder, rootDir } = context.options[0] || {};
+        const { allowSameFolder, rootDir } = {
+          allowSameFolder: context.options[0].allowSameFolder || false,
+          rootDir: context.options[0].rootDir || '',
+        };
 
         return {
           ImportDeclaration: function (node) {


### PR DESCRIPTION
Hi, thanks for creating this useful library.

In my usage, mostly on NestJS, I think it can't do what it should do in recognizing parent folders.
I don't know exactly why it happens in my environment, since this looks like a quite big issue if it doesn't work on every workspace.

Please review this patch. :)
Below is the description of this commit I wrote.

edit) I just realize that this issue is already reported. It can fix issue #9 , which is the exactly same as mine.

-----

When an import is something like the below,

import something from '../../some/folder';

Currently this plugin cannot fix that to be like,

import something from 'src/some/folder';

This because the `rootDir` variable in the `isParentFolder` function is
treated as `undefined` unless a user set that variable by its option.

So that patch will fix this that `rootDir` not to be `undefined`, rather it
makes that an empty string by setting a default value.

In the case of `allowSameFolder`, `undefined` will be treated as `false`
so it has been doing as it should be.

Signed-off-by: Deokgyu Yang <secugyu@gmail.com>