### PR TITLE
feat(): add CallExpression / ImportExpression

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,49 @@ function getAbsolutePath(relativePath, context, rootDir) {
     .join("/");
 }
 
+function checkImportCall(context, node, { allowSameFolder, rootDir }) {
+  let modulePath;
+  // refs https://github.com/estree/estree/blob/HEAD/es2020.md#importexpression
+  if (node.type === 'ImportDeclaration' || node.type === 'ImportExpression') {
+    modulePath = node.source;
+  } else if (node.type === 'CallExpression') {
+    if (node.callee.type !== 'Import') return;
+    if (node.arguments.length !== 1) return;
+
+    modulePath = node.arguments[0];
+  }
+
+  if (modulePath.type !== 'Literal') return;
+  if (typeof modulePath.value !== 'string') return;
+
+  const path  = modulePath.value;
+  if (isParentFolder(path, context, rootDir)) {
+    context.report({
+      node,
+      message: message,
+      fix: function (fixer) {
+        return fixer.replaceTextRange(
+          [node.source.range[0] + 1, node.source.range[1] - 1],
+          getAbsolutePath(path, context, rootDir || '')
+        );
+      },
+    });
+  }
+
+  if (isSameFolder(path) && !allowSameFolder) {
+    context.report({
+      node,
+      message: message,
+      fix: function (fixer) {
+        return fixer.replaceTextRange(
+          [node.source.range[0] + 1, node.source.range[1] - 1],
+          getAbsolutePath(path, context, rootDir || '')
+        );
+      },
+    });
+  }
+}
+
 const message = "import statements should have an absolute path";
 
 module.exports = {
@@ -35,39 +78,20 @@ module.exports = {
         fixable: "code",
       },
       create: function (context) {
-        const { allowSameFolder, rootDir } = {
+        const options = {
           allowSameFolder: context.options[0].allowSameFolder || false,
           rootDir: context.options[0].rootDir || '',
         };
 
         return {
           ImportDeclaration: function (node) {
-            const path = node.source.value;
-            if (isParentFolder(path, context, rootDir)) {
-              context.report({
-                node,
-                message: message,
-                fix: function (fixer) {
-                  return fixer.replaceTextRange(
-                    [node.source.range[0] + 1, node.source.range[1] - 1],
-                    getAbsolutePath(path, context, rootDir || '')
-                  );
-                },
-              });
-            }
-
-            if (isSameFolder(path) && !allowSameFolder) {
-              context.report({
-                node,
-                message: message,
-                fix: function (fixer) {
-                  return fixer.replaceTextRange(
-                    [node.source.range[0] + 1, node.source.range[1] - 1],
-                    getAbsolutePath(path, context, rootDir || '')
-                  );
-                },
-              });
-            }
+            checkImportCall(context, node, options);
+          },
+          CallExpression: function (node) {
+            checkImportCall(context, node, options);
+          },
+          ImportExpression: function (node) {
+            checkImportCall(context, node, options);
           },
         };
       },


### PR DESCRIPTION
Add Support for inline imports

```js
const Test = React.lazy(() => import("../../Test"))
```

Template: [import-js/eslint-plugin-import](https://github.com/import-js/eslint-plugin-import/blob/main/utils/moduleVisitor.js)