### PR TITLE
Support flat config format

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,22 @@ module.exports = {
       meta: {
         type: "layout",
         fixable: "code",
+        schema: {
+          type: "array",
+        	minItems: 0,
+        	maxItems: 1,
+        	items: [
+        		{
+        			type: "object",
+        			properties: {
+        				allowSameFolder: { type: "boolean" },
+        				rootDir: { type: "string" },
+        				prefix: { type: "string" },
+        			},
+        			additionalProperties: false,
+        		},
+        	],
+        },
       },
       create: function (context) {
         const { allowSameFolder, rootDir, prefix } = {

--- a/index.js
+++ b/index.js
@@ -37,19 +37,19 @@ module.exports = {
         fixable: "code",
         schema: {
           type: "array",
-        	minItems: 0,
-        	maxItems: 1,
-        	items: [
-        		{
-        			type: "object",
-        			properties: {
-        				allowSameFolder: { type: "boolean" },
-        				rootDir: { type: "string" },
-        				prefix: { type: "string" },
-        			},
-        			additionalProperties: false,
-        		},
-        	],
+          minItems: 0,
+          maxItems: 1,
+          items: [
+            {
+              type: "object",
+              properties: {
+                allowSameFolder: { type: "boolean" },
+                rootDir: { type: "string" },
+                prefix: { type: "string" },
+              },
+              additionalProperties: false,
+            },
+          ],
         },
       },
       create: function (context) {


### PR DESCRIPTION
Without the schema, you get an error like this:

```
Error: Key "rules": Key "no-relative-import-paths/no-relative-import-paths":
	Value [{"allowSameFolder":true}] should NOT have more than 0 items.
```