### PR TITLE
Feature: Add `allowedDepth` option for a limited amount of relative imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,30 @@ import Something from "../../components/something";
 // will result in
 import Something from "@/components/something";
 ```
+
+### `allowedDepth`
+
+Used to allow some relative imports of certain depths.
+
+Examples of code for this rule:
+
+```js
+// when configured as { "allowedDepth": 1 }
+
+// will NOT generate a warning
+import Something from "../components/something";
+
+// will generate a warning
+import Something from "../../components/something";
+```
+
+```js
+// when configured as { "allowedDepth": 2 }
+
+// will NOT generate a warning
+import Something from "../../components/something";
+
+// will generate a warning
+import Something from "../../../components/something";
+```
+


### PR DESCRIPTION
Implements #31 

This will allow consumers to configure an allowed amount of relative imports.

For my use case I would like most imports to be absolute, but would like to allow 2 levels of relative paths such as `../../` or `../` to not be considered a warning.

Let me know what you think, thanks!