### PR TITLE
Add option to remove slash after '@' prefix in import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,26 @@ import Something from "../../components/something";
 import Something from "@/components/something";
 ```
 
+### `noSlashAfterAt` 
+
+When true, this option prevents the insertion of a slash (/) after the @ symbol in the alias during auto-fix. This is useful in projects where imports are configured without the slash.
+
+Examples of code for this rule:
+
+```js
+// when configured as { "prefix": "@", "noSlashAfterAt": false } (default behavior)
+import Something from "../../components/something";
+
+// will result in
+import Something from "@/components/something";
+
+// when configured as { "prefix": "@", "noSlashAfterAt": true }
+import Something from "../../components/something";
+
+// will result in
+import Something from "@components/something";
+```
+
 ### `allowedDepth`
 
 Used to allow some relative imports of certain depths.

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function getRelativePathDepth(path) {
 }
 
 function getAbsolutePath(relativePath, context, rootDir, prefix, noSlashAfterAt) {
-  const absolutePth = [
+  return [
     prefix,
     ...path
       .relative(
@@ -33,8 +33,7 @@ function getAbsolutePath(relativePath, context, rootDir, prefix, noSlashAfterAt)
         path.join(path.dirname(context.getFilename()), relativePath)
       )
       .split(path.sep)
-  ].filter(String).join("/");
-  return noSlashAfterAt ? absolutePth.replace(`/`,`` ) : absolutePth;
+  ].filter(String).join("/").replace(noSlashAfterAt && prefix ? `/` : ``, ``);
 }
 
 const message = "import statements should have an absolute path";
@@ -57,7 +56,7 @@ module.exports = {
                 rootDir: { type: "string" },
                 prefix: { type: "string" },
                 allowedDepth: { type: "number" },
-                noSlashAfterAt: { type: "boolean" }, // Nueva opción
+                noSlashAfterAt: { type: "boolean" },
               },
               additionalProperties: false,
             },
@@ -70,7 +69,7 @@ module.exports = {
           allowSameFolder: context.options[0]?.allowSameFolder || false,
           rootDir: context.options[0]?.rootDir || '',
           prefix: context.options[0]?.prefix || '',
-          noSlashAfterAt: context.options[0]?.noSlashAfterAt || false, // Default: false
+          noSlashAfterAt: context.options[0]?.noSlashAfterAt || false,
         };
 
         return {

--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ function getRelativePathDepth(path) {
   return depth;
 }
 
-function getAbsolutePath(relativePath, context, rootDir, prefix) {
-  return [
+function getAbsolutePath(relativePath, context, rootDir, prefix, noSlashAfterAt) {
+  const absolutePth = [
     prefix,
     ...path
       .relative(
@@ -34,6 +34,7 @@ function getAbsolutePath(relativePath, context, rootDir, prefix) {
       )
       .split(path.sep)
   ].filter(String).join("/");
+  return noSlashAfterAt ? absolutePth.replace(`/`,`` ) : absolutePth;
 }
 
 const message = "import statements should have an absolute path";
@@ -56,6 +57,7 @@ module.exports = {
                 rootDir: { type: "string" },
                 prefix: { type: "string" },
                 allowedDepth: { type: "number" },
+                noSlashAfterAt: { type: "boolean" }, // Nueva opción
               },
               additionalProperties: false,
             },
@@ -63,11 +65,12 @@ module.exports = {
         },
       },
       create: function (context) {
-        const { allowedDepth, allowSameFolder, rootDir, prefix } = {
+        const { allowedDepth, allowSameFolder, rootDir, prefix, noSlashAfterAt } = {
           allowedDepth: context.options[0]?.allowedDepth,
           allowSameFolder: context.options[0]?.allowSameFolder || false,
           rootDir: context.options[0]?.rootDir || '',
           prefix: context.options[0]?.prefix || '',
+          noSlashAfterAt: context.options[0]?.noSlashAfterAt || false, // Default: false
         };
 
         return {
@@ -81,7 +84,7 @@ module.exports = {
                   fix: function (fixer) {
                     return fixer.replaceTextRange(
                       [node.source.range[0] + 1, node.source.range[1] - 1],
-                      getAbsolutePath(path, context, rootDir, prefix)
+                      getAbsolutePath(path, context, rootDir, prefix, noSlashAfterAt)
                     );
                   },
                 });
@@ -95,7 +98,7 @@ module.exports = {
                 fix: function (fixer) {
                   return fixer.replaceTextRange(
                     [node.source.range[0] + 1, node.source.range[1] - 1],
-                    getAbsolutePath(path, context, rootDir, prefix)
+                    getAbsolutePath(path, context, rootDir, prefix, noSlashAfterAt)
                   );
                 },
               });


### PR DESCRIPTION
## Add option to remove slash after '@' prefix in import paths
### **Description**:
This pull request introduces a new configuration option for the `no-relative-import-paths` ESLint rule that allows users to remove the slash (`/`) that follows the `@` prefix in import paths. 

#### **Key Features**:
- **New Option**: `noSlashAfterAt` (boolean)
  - When set to `true`, import paths prefixed with `@` will omit the slash after the prefix.
  - Example:
    - Input: `import ActionCard from '../../components/ActionCard';`
    - Output: `import ActionCard from '@components/ActionCard';`

#### **Backward Compatibility**:
- The existing functionality remains unchanged if the new option is not used.
- Default behavior ensures that existing users of the plugin are not affected by this change.

#### **Usage**:
To activate this feature, add the following to your ESLint configuration:

```json
{
  "rules": {
    "no-relative-import-paths/no-relative-import-paths": [
      "warn",
      {
        "allowSameFolder": true,
        "rootDir": "src",
        "prefix": "@",
        "noSlashAfterAt": true
      }
    ]
  }
}