### PR TITLE
Support case where prefix is a slash in generating absolute paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function getAbsolutePath(relativePath, context, rootDir, prefix) {
         path.join(path.dirname(context.getFilename()), relativePath)
       )
       .split(path.sep)
-  ].filter(String).join("/");
+  ].filter(String).join("/").replace(/^\/\//, '/');
 }
 
 const message = "import statements should have an absolute path";


### PR DESCRIPTION
- Added replacement to handle double slashes at the start of generated paths when the prefix is a slash.