### PR TITLE
Support "." paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function isParentFolder(relativeFilePath, context, rootDir) {
 }
 
 function isSameFolder(path) {
-  return path.startsWith("./");
+  return path.startsWith("./") || path === ".";
 }
 
 function getRelativePathDepth(path) {


### PR DESCRIPTION
On imports not at the top level directory such as `import function from ".";` within `src/files/functions/` this rule does not see and correct them to `import function from "@files/functions"`