### PR TITLE
fix(eslint): update deprecated APIs for ESLint v10 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 const path = require("path");
 
 function isParentFolder(relativeFilePath, context, rootDir) {
-  const absoluteRootPath = path.join(context.getCwd(), rootDir);
-  const absoluteFilePath = path.join(path.dirname(context.getFilename()), relativeFilePath)
+  const absoluteRootPath = path.join(context.cwd, rootDir);
+  const absoluteFilePath = path.join(path.dirname(context.filename), relativeFilePath)
 
   return relativeFilePath.startsWith("../") && (
     rootDir === '' ||
     (absoluteFilePath.startsWith(absoluteRootPath) &&
-      context.getFilename().startsWith(absoluteRootPath))
+      context.filename.startsWith(absoluteRootPath))
   );
 }
 
@@ -29,8 +29,8 @@ function getAbsolutePath(relativePath, context, rootDir, prefix) {
     prefix,
     ...path
       .relative(
-        path.join(context.getCwd(), rootDir),
-        path.join(path.dirname(context.getFilename()), relativePath)
+        path.join(context.cwd, rootDir),
+        path.join(path.dirname(context.filename), relativePath)
       )
       .split(path.sep)
   ].filter(String).join("/");


### PR DESCRIPTION
### Context

This plugin is not compatible with *ESLint v10* because it relies on APIs that were deprecated in v9 and removed in v10.

In particular, it uses the following removed RuleContext methods:
- context.getCwd()
- context.getFilename()

See: https://eslint.org/blog/2026/02/eslint-v10.0.0-released/#removed-deprecated-rule-context-members

### Fix
Replaced usages of the removed RuleContext methods with their corresponding supported properties/getters. This restores compatibility with ESLint v10 while maintaining backward compatibility with ESLint v9.